### PR TITLE
More specific codec testing and add support for AV1

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,12 +1,12 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS build
 
 # FROM https://trac.ffmpeg.org/wiki/CompilationGuide/Centos
-RUN dnf install -y autoconf automake bzip2 bzip2-devel cmake gcc gcc-c++ git libtool make pkgconfig zlib-devel diffutils perl
+RUN dnf install -y autoconf automake bzip2 bzip2-devel cmake gcc gcc-c++ git libtool make pkgconfig zlib-devel diffutils perl meson ninja-build
 RUN dnf remove nasm
 RUN mkdir /tmp/ffmpeg_sources
 RUN mkdir /tmp/bin
 ENV PATH="$PATH:/tmp/bin"
-ENV PKG_CONFIG_PATH="/tmp/ffmpeg_build/lib/pkgconfig"
+ENV PKG_CONFIG_PATH="/tmp/ffmpeg_build/lib/pkgconfig:/tmp/ffmpeg_build/lib64/pkgconfig"
 
 ## NASM
 RUN cd /tmp/ffmpeg_sources \
@@ -75,12 +75,22 @@ RUN cd /tmp/ffmpeg_sources \
     && make \
     && make install
 
+## av1 support
+RUN cd /tmp/ffmpeg_sources \
+    && git clone --branch 1.4.3 --depth 1 https://code.videolan.org/videolan/dav1d.git \
+    && cd dav1d \
+    && mkdir build \
+    && cd build \
+    && meson --default-library=static --prefix="/tmp/ffmpeg_build" --bindir="/tmp/bin" .. \
+    && ninja \
+    && ninja install
+
 ## ffmpeg
 RUN cd /tmp/ffmpeg_sources \
     && curl -O -L https://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 \
     && tar xjvf ffmpeg-snapshot.tar.bz2 \
     && cd ffmpeg \
-    && ./configure --prefix="/tmp/ffmpeg_build" --pkg-config-flags="--static" --extra-cflags="-I/tmp/ffmpeg_build/include" --extra-ldflags="-L/tmp/ffmpeg_build/lib" --extra-libs="-lpthread -lm -lz" --bindir="/tmp/bin" --enable-gpl --enable-libfdk_aac --enable-libmp3lame --enable-libopus --enable-libvpx --enable-libx264 --enable-nonfree --enable-yasm --enable-static --disable-shared --strip="$(type -P strip)" \
+    && ./configure --prefix="/tmp/ffmpeg_build" --pkg-config-flags="--static" --extra-cflags="-I/tmp/ffmpeg_build/include" --extra-ldflags="-L/tmp/ffmpeg_build/lib" --extra-libs="-lpthread -lm -lz" --bindir="/tmp/bin" --enable-gpl --enable-libfdk_aac --enable-libmp3lame --enable-libopus --enable-libvpx --enable-libx264 --enable-libdav1d --enable-nonfree --enable-yasm --enable-static --disable-shared --strip="$(type -P strip)" \
     && make \
     && make install
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -92,11 +92,23 @@ COPY --from=build /tmp/bin/ffprobe /bin/ffprobe
 ## Run a validation test
 FROM final AS test
 
-RUN mkdir /tmp/test \
-    && cd /tmp/test \
-    && curl -O -L  https://www3.cde.ca.gov/download/rod/big_buck_bunny.mp4
+RUN mkdir /tmp/test
 
-RUN /bin/ffmpeg -i /tmp/test/big_buck_bunny.mp4 -vf fps=5 -t 10 -vcodec rawvideo -pix_fmt rgb24 /tmp/test/output_%03d.png
+# Codec: H264 - MPEG-4 AVC (part 10) (avc1)
+RUN curl https://www3.cde.ca.gov/download/rod/big_buck_bunny.mp4 -o /tmp/test/h264.mp4
+RUN /bin/ffmpeg -i /tmp/test/h264.mp4 -vf fps=5 -t 10 -vcodec rawvideo -pix_fmt rgb24 /tmp/test/h264_%03d.png
+
+# Codec: MPEG-H Part2/HEVC (H.265) (hev1)
+RUN curl https://www.elecard.com/storage/video/TSU_854x480.mp4 -o /tmp/test/h265.mp4
+RUN /bin/ffmpeg -i /tmp/test/h264.mp4  -vf fps=5 -t 10 -vcodec rawvideo -pix_fmt rgb24 /tmp/test/h265_%03d.png
+
+# Codec: Google/On2's VP9 Video (VP90)
+RUN curl https://www.elecard.com/storage/video/UshaikaRiverEmb_854x480.webm -o /tmp/test/VP9.webm
+RUN /bin/ffmpeg -i /tmp/test/VP9.webm -vf fps=5 -t 10 -vcodec rawvideo -pix_fmt rgb24 /tmp/test/VP9_%03d.png
+
+# Codec: AOMedia's AV1 Video (av01)
+RUN curl https://www.elecard.com/storage/video/CityHall_854x480.webm -o /tmp/test/AV1.webm
+RUN /bin/ffmpeg -i /tmp/test/AV1.webm -vf fps=5 -t 10 -vcodec rawvideo -pix_fmt rgb24 /tmp/test/AV1_%03d.png
 
 # publish final
 FROM final AS publish


### PR DESCRIPTION
I wanted to add a few more tests cases to ensure we had a build that would support other video codecs we might find in the wild.

While adding these test cases, I discovered we didn't support AV1. 🔴 

AV1 has [high adoption](https://en.wikipedia.org/wiki/AV1#Content_providers) among a few of our target providers, so will likely be needed.  Adding support required pulling in an additional lib and dependencies to build it.  🟢 

